### PR TITLE
Add Chrome extension for m3u8 playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# np-player
+# m3u8 Player Chrome Extension
+
+This extension detects `contentUrl` values ending with `.m3u8` inside `script[type="application/ld+json"]` elements on any page. When detected, a button is inserted that opens a new tab with a simple React-based player using **hls.js**.
+
+## Development
+
+Install dependencies and build the scripts:
+
+```bash
+npm install
+npm run build
+```
+
+Load the `np-player` folder as an unpacked extension in Chrome.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": 3,
+  "name": "m3u8 Player Launcher",
+  "version": "1.0.0",
+  "permissions": [
+    "tabs",
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "background": {
+    "service_worker": "dist/background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "dist/content.js"
+      ]
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "play.html",
+        "dist/index.js",
+        "dist/Player.js"
+      ],
+      "matches": [
+        "<all_urls>"
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,133 @@
+{
+  "name": "np-player",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "np-player",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "hls.js": "^1.6.5",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0"
+      },
+      "devDependencies": {
+        "@types/chrome": "^0.0.329",
+        "@types/react": "^19.1.8",
+        "@types/react-dom": "^19.1.6",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.0.329",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.329.tgz",
+      "integrity": "sha512-jAZX4QMnAa1bTSWoQ5/EhhiY1t+1B7a5ZCY5ZEs61tWiQfxXAkfBSxCkQWhGxJoiq/4b4vtcmYEebNEmlLKecg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
+      }
+    },
+    "node_modules/@types/filesystem": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.36.tgz",
+      "integrity": "sha512-vPDXOZuannb9FZdxgHnqSwAG/jvdGM8Wq+6N4D/d80z+D4HWH+bItqsZaVRQykAn6WEVeEkLm2oQigyHtgb0RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/filewriter": "*"
+      }
+    },
+    "node_modules/@types/filewriter": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.33.tgz",
+      "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/har-format": {
+      "version": "1.2.16",
+      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.16.tgz",
+      "integrity": "sha512-fluxdy7ryD3MV6h8pTfTYpy/xQzCFC7m89nOH9y94cNqJ1mDIDPut7MnRHI3F6qRmh/cT2fUjG1MLdCNb4hE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
+      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.5.tgz",
+      "integrity": "sha512-KMn5n7JBK+olC342740hDPHnGWfE8FiHtGMOdJPfUjRdARTWj9OB+8c13fnsf9sk1VtpuU2fKSgUjHvg4rNbzQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "np-player",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "hls.js": "^1.6.5",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
+  },
+  "devDependencies": {
+    "@types/chrome": "^0.0.329",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "typescript": "^5.8.3"
+  }
+}

--- a/play.html
+++ b/play.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <title>m3u8プレイヤー</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="index.js"></script>
+  </body>
+</html>

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useRef } from 'react';
+import Hls from 'hls.js';
+
+const getM3u8Url = (): string | null => {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('url');
+};
+
+const Player: React.FC = () => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    const url = getM3u8Url();
+    const video = videoRef.current;
+    if (!video || !url) return;
+
+    if (Hls.isSupported()) {
+      const hls = new Hls();
+      hls.loadSource(url);
+      hls.attachMedia(video);
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      video.src = url;
+    }
+  }, []);
+
+  return (
+    <div style={{width: '100%', height: '100vh', background: '#000', display: 'flex', justifyContent: 'center', alignItems: 'center', flexDirection: 'column'}}>
+      <video ref={videoRef} controls style={{maxWidth: '90vw', maxHeight: '80vh'}} autoPlay />
+      <div style={{color: '#fff', marginTop: '1rem'}}>m3u8動画を再生中</div>
+    </div>
+  );
+};
+
+export default Player;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,7 @@
+// background.ts - opens player tab on message
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.m3u8Url) {
+    const url = chrome.runtime.getURL(`play.html?url=${encodeURIComponent(msg.m3u8Url)}`);
+    chrome.tabs.create({ url });
+  }
+});

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,0 +1,35 @@
+// content.ts - content script to find m3u8 URL and insert a play button
+
+function findM3u8Url(): string | null {
+  const scripts = document.querySelectorAll<HTMLScriptElement>('script[type="application/ld+json"]');
+  for (const script of Array.from(scripts)) {
+    try {
+      const data = JSON.parse(script.textContent || '');
+      if (typeof data === 'object' && data && data.contentUrl && typeof data.contentUrl === 'string' && data.contentUrl.endsWith('.m3u8')) {
+        return data.contentUrl;
+      }
+    } catch (err) {
+      // ignore parse errors
+    }
+  }
+  return null;
+}
+
+function insertPlayButton(url: string) {
+  if (document.getElementById('__m3u8play_btn')) return;
+  const btn = document.createElement('button');
+  btn.id = '__m3u8play_btn';
+  btn.textContent = 'm3u8を別タブで再生';
+  btn.style.cssText = 'z-index:10000;position:fixed;top:10px;right:10px;padding:8px 16px;background:orange;color:#222;font-size:16px;border-radius:6px;';
+  btn.addEventListener('click', () => {
+    chrome.runtime.sendMessage({ m3u8Url: url });
+  });
+  document.body.appendChild(btn);
+}
+
+const url = findM3u8Url();
+if (url) {
+  insertPlayButton(url);
+}
+
+export {}; // ensure this file is a module

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import Player from './Player';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<Player />);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "es2020",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- implement Chrome extension to parse pages for `contentUrl` ending with `.m3u8`
- add button that launches a React player in a new tab
- use `hls.js` to play streams
- provide `npm run build` script and instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68657bc3dac8832585c35d79a4cddfef